### PR TITLE
Add typing for IsomorphicDOMPurify

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+import * as DOMPurify from 'dompurify';
+export = DOMPurify

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "browser.js"
   ],
   "license": "MIT",
@@ -21,7 +22,9 @@
   "browser": "browser.js",
   "main": "index.js",
   "dependencies": {
+    "@types/dompurify": "^2.0.1",
     "dompurify": "^2.0.8",
     "jsdom": "^16.2.1"
-  }
+  },
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
Addresses issue #1 

### Summary of Changes
https://www.npmjs.com/package/@types/dompurify contains the [most up to date types for DOMPurify](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/dompurify/index.d.ts). This PR re-exports those defined types so that users of `isomorphic-dompurify` can make use of them in their typescript project without needing to install DOMPurify at all.

### Example Usage

**Typescript**
```ts
// example.ts
import DOMPurify, {Config} from 'isomorphic-dompurify';

const options: Config = {
    ADD_TAGS: ['iframe'],
    FORCE_BODY: true,
    USE_PROFILES: {svg: true, svgFilters: true, html: true},
  }
const output = DOMPurify.sanitize("<foo></foo>", options) as string;
```

**Default import**

When importing using a CommonJS `const x = require(...)` or ES6 default import `import x from ...`, the code editor's intellisense will be able to make use of types even in a regular `.js` file. (See gif below)

![Intellisense](https://user-images.githubusercontent.com/15018469/78305256-7455e680-750e-11ea-97ab-688b56f7b5b0.gif)

The full list of types that DOMPurify exports can be found in the [original definition file here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/dompurify/index.d.ts).

### How to test these changes
These steps will allow you to test the changes without needing to setup a typescript project. 

* Create a new directory and create a file called `run.js` in it.
* Run `npm init` to initialize a package.json in this test app directory 
* Run `npm link`. This will allow you to load in local npm modules.
* In your `run.js` file add the following code 
```js
// substitute in the absolute path to your isomorphic-dompurify code
const DOMPurify = require("/Users/ellul/src/github.com/kkomelin/isomorphic-dompurify");
```
* You should now see that if you type `DOMPurify.` like in the gif above you will have autocomplete options based on the types.
* Additionally in some code editors like VSCode, you can `ctrl-click` on the `DOMPurify` variable name and be brought to its type definition file (as seen below)
![Gotodefinition 2020-04-02 20-13-29](https://user-images.githubusercontent.com/15018469/78311322-8049a480-751e-11ea-84dc-d0620104611c.gif)
* Repeat the same instructions as above but instead import the code using the ES6 import method along with all the named types that are also exported.
```js
import DOMPurify, {
    DOMPurifyI,
    Config,
    HookName,
    HookEvent,
    SanitizeElementHookEvent,
    SanitizeAttributeHookEvent,
} from "/Users/ellul/src/github.com/kkomelin/isomorphic-dompurify";
```