### PR TITLE
Update README.md for optimized imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Please note that DOMPurify library [doesn't follow Semantic Versioning](https://
 
 ```javascript
 // Import as an ES6 module.
+
+import { sanitize, isSupported } from "isomorphic-dompurify";
+
+// Or
+
 import DOMPurify from 'isomorphic-dompurify';
 
 // Or as a CommonJS module.


### PR DESCRIPTION
use ECMA 6 way of import so instead of importing whole library, you can import only required functions or other stuffs