### PR TITLE
Change a way we distinguish client from server

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-function e(e){return e&&e.default||e}module.exports=global.DOMPurify=global.DOMPurify||("undefined"==typeof process?e(require("dompurify")):function(){const r=e(require("dompurify")),{JSDOM:u}=e(require("jsdom")),{window:o}=new u("<!DOCTYPE html>");return r(o)}());
+function e(e){return e&&e.default||e}module.exports=global.DOMPurify=global.DOMPurify||("undefined"!=typeof window?e(require("dompurify")):function(){const r=e(require("dompurify")),{JSDOM:u}=e(require("jsdom")),{window:o}=new u("<!DOCTYPE html>");return r(o)}());

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ function initDOMPurifyWithJSDOM() {
 }
 
 function resolveDOMPurify() {
-  const isClientSide = typeof process === 'undefined';
+  const isClientSide = typeof window !== 'undefined';
   return isClientSide ? importModule(require('dompurify')) : initDOMPurifyWithJSDOM();
 }
 


### PR DESCRIPTION
From @kkomelin :

Previous condition `typeof process === 'undefined'` that detected client stopped working when some frameworks started to misuse the `process` variable, so we need to find a better way to distinguish client from server.

Many libraries are using the `typeof window !== 'undefined'` condition to detect the client instead, and it's currently the best known way to do it, so let's switch to it.

Even though the change is more or less safe, we are planning to release a new major version to avoid breaking things.