### PR TITLE
Web Worker Support

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,1 +1,1 @@
-module.exports = window.DOMPurify || (window.DOMPurify = require('dompurify').default || require('dompurify'));
+module.exports = self.DOMPurify || (self.DOMPurify = require('dompurify').default || require('dompurify'));


### PR DESCRIPTION
## Current Behavior

When importing into a worker environment the following runtime error occurs

```
Uncaught ReferenceError: window is not defined
    at node_modules/.pnpm/isomorphic-dompurify@1.13.0_bufferutil@4.0.8/node_modules/isomorphic-dompurify/browser.js (isomorphic-dompurify.js?v=650fd638:949:22)
```

## Change in behavior

The runtime error does not occur and `DOMPurify` is accessible both as a export
and on `self.DOMPurify`/`globalThis.DOMPurify` in workers

## Developer Notes

There are probably a dozen different ways to fix this issue, the one chosen was
picked for being the one with the fewest number of changes while being
backwards compatible all the way back to browser versions from 2012 (Firefox
back to 2004)

See: <https://developer.mozilla.org/en-US/docs/Web/API/Window/self#examples>

### Other approaches considered

- Using `typeof window !== "unefined"`
  - This method of determining if the `window` exists and if this code is
  executing in a worker was considered however after this check was done the
  split in exuection after this was detected would have either needed to use
  `self` or pollyfil `window` on `self`. Since `self` always works it seemed
  more straight forward to just always use it instead of `window`

Example:

```js
const globalObject = typeof window !== "undefined" ? window : self;
module.exports = globalObject.DOMPurify || (globalObject.DOMPurify = require('dompurify').default || require('dompurify'));
```

- Using `globalThis`
  - This method would be better if trying to target the same code on server and
  browser however it is a much newer feature and not available on all platforms
  (ie, React Native, etc.)

Example:

```js
module.exports = globalThis.DOMPurify || (globalThis.DOMPurify = require('dompurify').default || require('dompurify'));
```

- Using `typeof window !== "undefined"` but not assigning to `self.DOMPurify`
  - This would simply remove the accessing of `window` in worker environments
  effectively killing the polyfil nature of this in worker environments but
  still allowing the import

Example:

```js
const dompurify = require("dompurify")

if (typeof window !== "undefined") {
  window.DOMPurify = window.DOMPurify || dompurify.default || dompurify;
}

module.exports = typeof window !== "undefined" ? window.DOMPurify : dompurify.default || dompurify;
```

- Using optional chaning
  - This would have had the same outcome of not having `DOMPurify` accessible on
    `self`/`globalThis` as the previous method however it would rely on a feature
    only aviable in newer JavaScript environments.

Example:

```js
const dompurify = require("dompurify")

if (typeof window !== "undefined") {
  window.DOMPurify = window.DOMPurify || dompurify.default || dompurify;
}

module.exports = window?.DOMPurify || dompurify.default || dompurify;
```

- Using null coalescing
  - Again this feature is very new and not supported in every environment

```js
const dompurify = require("dompurify")

if (typeof window !== "undefined") {
  window.DOMPurify ??= dompurify.default || dompurify;
}

module.exports = window?.DOMPurify : dompurify.default || dompurify;
```
