### PR TITLE
Update DOMPurify to 3.2.4 (latest)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "dompurify": "^3.2.3",
+    "dompurify": "^3.2.4",
     "jsdom": "^26.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       dompurify:
-        specifier: ^3.2.3
+        specifier: ^3.2.4
         version: 3.2.4
       jsdom:
         specifier: ^26.0.0


### PR DESCRIPTION
## Summary

Resolves #319 by updating DOMPurify to 3.2.4. 

See https://github.com/cure53/DOMPurify/releases for release notes. 