### PR TITLE
fix(package): add exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,18 @@
   "browser": "browser.js",
   "main": "index.js",
   "types": "index.d.ts",
+  "exports": {
+    "node": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "require": "./index.js"
+    },
+    "default": {
+      "types": "./index.d.ts",
+      "import": "./browser.js",
+      "require": "./browser.js"
+    }
+  },
   "dependencies": {
     "dompurify": "^3.2.6",
     "jsdom": "^26.1.0"


### PR DESCRIPTION
Adds entrypoint information for modern bundlers.

Should resolve
- https://github.com/kkomelin/isomorphic-dompurify/issues/347
- https://github.com/kkomelin/isomorphic-dompurify/issues/228
- https://github.com/kkomelin/isomorphic-dompurify/issues/214
- https://github.com/vercel/next.js/discussions/58142

More information:
- https://nodejs.org/api/packages.html#exports
- https://nodejs.org/api/packages.html#package-entry-points
- https://nodejs.org/api/packages.html#nested-conditions

---

I'd also like to push for ESM support (https://github.com/kkomelin/isomorphic-dompurify/issues/163) for which I imagine the code to be written in TypeScript and compiled to `.cjs` and `.mjs` outputs, but that's maybe a bit offtopic here.