### PR TITLE
feat: export hook-related TypeScript types (#427)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ const purify = DOMPurify(new JSDOM().window);
 const clean = purify.sanitize(dirtyString);
 ```
 
+## TypeScript
+
+The hook-related types from `dompurify` are re-exported, so you can type your `addHook` callbacks without redeclaring the signatures:
+
+```typescript
+import { addHook, type NodeHook } from "isomorphic-dompurify";
+
+const stripTargetBlank: NodeHook = function (node) {
+  if ("target" in node) (node as Element).removeAttribute("target");
+};
+
+addHook("afterSanitizeAttributes", stripTargetBlank);
+```
+
+Available type re-exports: `Config`, `DOMPurify`, `DocumentFragmentHook`, `ElementHook`, `HookName`, `NodeHook`, `RemovedAttribute`, `RemovedElement`, `UponSanitizeAttributeHook`, `UponSanitizeAttributeHookEvent`, `UponSanitizeElementHook`, `UponSanitizeElementHookEvent`, `WindowLike`.
+
 ## Memory Management (Server)
 
 In long-running Node.js processes, the internal jsdom window accumulates DOM state across sanitization calls, which can cause progressive slowdown and memory growth. Use `clearWindow()` to periodically release these resources:

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isomorphic-dompurify",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "Makes it possible to use DOMPurify on server and client in the same way.",
   "keywords": [
     "security",
@@ -78,7 +78,7 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   },
-  "packageManager": "pnpm@10.33.1",
+  "packageManager": "pnpm@10.33.2",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
   }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -16,3 +16,19 @@ export const removed = DOMPurify.removed
 export function clearWindow(): void {
   // No-op in browser — no jsdom window to manage
 }
+
+export type {
+  Config,
+  DOMPurify,
+  DocumentFragmentHook,
+  ElementHook,
+  HookName,
+  NodeHook,
+  RemovedAttribute,
+  RemovedElement,
+  UponSanitizeAttributeHook,
+  UponSanitizeAttributeHookEvent,
+  UponSanitizeElementHook,
+  UponSanitizeElementHookEvent,
+  WindowLike,
+} from 'dompurify'

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,19 @@ export function clearWindow(): void {
   window = new JSDOM('<!DOCTYPE html>').window
   purify = DOMPurifyFactory(window as unknown as Parameters<typeof DOMPurifyFactory>[0])
 }
+
+export type {
+  Config,
+  DOMPurify,
+  DocumentFragmentHook,
+  ElementHook,
+  HookName,
+  NodeHook,
+  RemovedAttribute,
+  RemovedElement,
+  UponSanitizeAttributeHook,
+  UponSanitizeAttributeHookEvent,
+  UponSanitizeElementHook,
+  UponSanitizeElementHookEvent,
+  WindowLike,
+} from 'dompurify'

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from 'vitest'
+import type { NodeHook as BrowserNodeHook } from '../src/browser'
+import {
+  addHook,
+  type Config,
+  type DocumentFragmentHook,
+  type ElementHook,
+  type HookName,
+  type NodeHook,
+  type RemovedAttribute,
+  type RemovedElement,
+  removeAllHooks,
+  sanitize,
+  type UponSanitizeAttributeHook,
+  type UponSanitizeElementHook,
+} from '../src/index'
+
+test('hook types are re-exported and accepted by addHook', () => {
+  const nodeHook: NodeHook = (currentNode) => {
+    void currentNode
+  }
+  const elementHook: ElementHook = (currentNode) => {
+    void currentNode
+  }
+  const fragmentHook: DocumentFragmentHook = (currentNode) => {
+    void currentNode
+  }
+  const onElement: UponSanitizeElementHook = (currentNode, data) => {
+    void currentNode
+    void data.tagName
+  }
+  const onAttribute: UponSanitizeAttributeHook = (currentNode, data) => {
+    void currentNode
+    void data.attrName
+  }
+
+  const beforeElements: HookName = 'beforeSanitizeElements'
+  const beforeAttributes: HookName = 'beforeSanitizeAttributes'
+  const beforeShadow: HookName = 'beforeSanitizeShadowDOM'
+
+  addHook(beforeElements as 'beforeSanitizeElements', nodeHook)
+  addHook(beforeAttributes as 'beforeSanitizeAttributes', elementHook)
+  addHook(beforeShadow as 'beforeSanitizeShadowDOM', fragmentHook)
+  addHook('uponSanitizeElement', onElement)
+  addHook('uponSanitizeAttribute', onAttribute)
+
+  expect(sanitize('<b>ok</b>')).toBe('<b>ok</b>')
+  removeAllHooks()
+})
+
+test('Config and Removed* types align with runtime API', () => {
+  const config: Config = { ALLOWED_TAGS: ['b'] }
+  expect(sanitize('<b>x</b><i>y</i>', config)).toBe('<b>x</b>y')
+
+  const item: RemovedElement | RemovedAttribute = { element: {} as Node }
+  expect(item).toBeDefined()
+})
+
+test('browser entry re-exports NodeHook as well', () => {
+  const hook: BrowserNodeHook = (currentNode) => {
+    void currentNode
+  }
+  expect(typeof hook).toBe('function')
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "skipLibCheck": true,
     "outDir": "dist"
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
## Summary
- Re-export hook-related TypeScript types (`NodeHook`, `ElementHook`, `DocumentFragmentHook`, `UponSanitizeElementHook`, `UponSanitizeAttributeHook`, `HookName`) plus adjacent surface types (`Config`, `DOMPurify`, `RemovedAttribute`, `RemovedElement`, `UponSanitizeAttributeHookEvent`, `UponSanitizeElementHookEvent`, `WindowLike`) from `dompurify` so consumers can type `addHook` callbacks without redeclaring the signatures.
- Document the new types in the README with a copy-friendly example.
- Bump version to `3.11.0` (minor - additive type-only public surface).

Closes #427

## Test plan
- [x] `pnpm typecheck` clean (now also covers `tests/`)
- [x] `pnpm lint` clean
- [x] `pnpm test` - 12/12 passing, including new `tests/types.test.ts` smoke assertions for both `src/index` and `src/browser` entries
- [x] `pnpm build` - verified `dist/index.d.ts` and `dist/browser.d.ts` re-export all 13 type names; runtime `dist/*.js` correctly omits the type-only re-exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exported TypeScript type definitions for DOMPurify configuration, hooks, and related types to improve type safety for developers.

* **Documentation**
  * Added comprehensive README section for TypeScript users with examples of using exported types and hook callbacks.

* **Tests**
  * Added type validation tests to ensure exported types integrate correctly with the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->